### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,23 +12,23 @@ MD_KeySwitch	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setDebounceTime KEYWORD2
-setDoublePressTime KEYWORD2
-setRepeatTime KEYWORD2
-setLongPressTime KEYWORD2
-enableRepeat  KEYWORD2
-enableDoublePress KEYWORD2
-enableLongPress KEYWORD2
-enableRepeatResult  KEYWORD2
-begin KEYWORD2
-read KEYWORD2
+setDebounceTime	KEYWORD2
+setDoublePressTime	KEYWORD2
+setRepeatTime	KEYWORD2
+setLongPressTime	KEYWORD2
+enableRepeat	KEYWORD2
+enableDoublePress	KEYWORD2
+enableLongPress	KEYWORD2
+enableRepeatResult	KEYWORD2
+begin	KEYWORD2
+read	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)
 #######################################
 
-KS_NULL LITERAL1
-KS_PRESS LITERAL1
-KS_DPRESS LITERAL1
-KS_LONGPRESS LITERAL1
-KS_RPTPRESS LITERAL1
+KS_NULL	LITERAL1
+KS_PRESS	LITERAL1
+KS_DPRESS	LITERAL1
+KS_LONGPRESS	LITERAL1
+KS_RPTPRESS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords